### PR TITLE
Fixed IsParameterTrue() for /params (matches Framework behavior)

### DIFF
--- a/System.Configuration.Install.Tests/System.Configuration.Install/InstallContextTests.cs
+++ b/System.Configuration.Install.Tests/System.Configuration.Install/InstallContextTests.cs
@@ -12,5 +12,18 @@ namespace System.Configuration.Install.Tests.System.Configuration.Install
             Assert.AreEqual("/var/log/log.log", installContext.Parameters["logFile"]);
             Assert.AreEqual("true", installContext.Parameters["LogToConsole"]);
         }
+
+        [TestMethod]
+        public void Should_Return_Parameter_True_For_Parameters()
+        {
+            var installContext = new InstallContext("/var/log/log.log", new[] { "/whatever", "/i", "-debug" });
+
+            Assert.IsTrue(installContext.IsParameterTrue("debug"));
+            Assert.IsTrue(installContext.IsParameterTrue("Debug"));
+            Assert.IsTrue(installContext.IsParameterTrue("i"));
+            Assert.IsTrue(installContext.IsParameterTrue("I"));
+            Assert.IsTrue(installContext.IsParameterTrue("whatever"));
+            Assert.IsTrue(installContext.IsParameterTrue("Whatever"));
+        }
     }
 }

--- a/System.Configuration.Install/System.Configuration.Install/InstallContext.cs
+++ b/System.Configuration.Install/System.Configuration.Install/InstallContext.cs
@@ -111,7 +111,7 @@ namespace System.Configuration.Install
 			}
 			for (var i = 0; i < args.Length; i++)
 			{
-				if (args[i].StartsWith("-", StringComparison.Ordinal))
+				if (args[i].StartsWith("/", StringComparison.Ordinal) || args[i].StartsWith("-", StringComparison.Ordinal))
 				{
 					args[i] = args[i].Substring(1);
 				}


### PR DESCRIPTION
When using a param like `/i` or `/debug`, `InstallContext` is returning false for `IsParameterTrue()`. This is not the case in the Framework.

I used decompiled sources (dnSpy) to figure out the difference and added the extra check from 4.0.0.0 decompilation to `InstallContext`.

Added a test to validate (was red before; is green now).